### PR TITLE
Add generic read infrastructure

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,23 +89,33 @@ pub trait Register {
     fn rx_buffer(&mut self) -> &mut [u8];
 }
 
+macro_rules! impl_register {
+    ($($id:expr, $len:expr, $name:ident; #[$doc:meta])*) => {
+        $(
+            #[$doc]
+            #[allow(non_camel_case_types)]
+            pub struct $name([u8; $len + 1]);
 
-/// Device identifier - includes device type and revision info
-#[allow(non_camel_case_types)]
-pub struct DEV_ID([u8; 5]);
+            impl Register for $name {
+                const ID:  u8    = $id;
+                const LEN: usize = $len;
 
-impl Register for DEV_ID {
-    const ID:  u8    = 0x00;
-    const LEN: usize = 4;
+                fn new() -> Self {
+                    $name([0; $len + 1])
+                }
 
-    fn new() -> Self {
-        DEV_ID([0; 5])
-    }
-
-    fn rx_buffer(&mut self) -> &mut [u8] {
-        &mut self.0
+                fn rx_buffer(&mut self) -> &mut [u8] {
+                    &mut self.0
+                }
+            }
+        )*
     }
 }
+
+impl_register! {
+    0x00, 4, DEV_ID; /// Device identifier
+}
+
 
 impl DEV_ID {
     /// Register Identification Tag

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,15 +45,15 @@ impl<SPI> DW1000<SPI> where SPI: SpimExt {
         }
     }
 
-    /// Read the device identifier (DEV_ID)
-    pub fn dev_id(&mut self) -> Result<DEV_ID, spim::Error> {
+    /// Read a register
+    pub fn read<R: Register>(&mut self) -> Result<R, spim::Error> {
         let header =
-            (0          & 0x80) |  // read
-            (0          & 0x40) |  // no sub-index
-            (DEV_ID::ID & 0x3f);   // index of DEV_ID register
+            (0     & 0x80) |  // read
+            (0     & 0x40) |  // no sub-index
+            (R::ID & 0x3f);   // index of the register
         let tx_buffer = [header];
 
-        let mut r = DEV_ID::new();
+        let mut r = R::new();
 
         self.spim.read(&mut self.chip_select, &tx_buffer, r.rx_buffer())?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,7 @@ macro_rules! impl_register {
 
 impl_register! {
     0x00, 4, DEV_ID; /// Device identifier
+    0x01, 8, EUI;    /// Extended Unique Identifier
 }
 
 
@@ -139,10 +140,27 @@ impl DEV_ID {
     }
 }
 
+impl EUI {
+    /// Extended Unique Identifier
+    pub fn eui(&self) -> u64 {
+        ((self.0[8] as u64) << 56) |
+            ((self.0[7] as u64) << 48) |
+            ((self.0[6] as u64) << 40) |
+            ((self.0[5] as u64) << 32) |
+            ((self.0[4] as u64) << 24) |
+            ((self.0[3] as u64) << 16) |
+            ((self.0[2] as u64) <<  8) |
+            self.0[1] as u64
+    }
+}
+
 
 #[cfg(test)]
 mod tests {
-    use super::DEV_ID;
+    use super::{
+        DEV_ID,
+        EUI,
+    };
 
 
     #[test]
@@ -153,5 +171,12 @@ mod tests {
         assert_eq!(dev_id.ver()   , 3     );
         assert_eq!(dev_id.model() , 1     );
         assert_eq!(dev_id.ridtag(), 0xDECA);
+    }
+
+    #[test]
+    fn eui_should_provide_access_to_its_field() {
+        let eui = EUI([0x00, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0]);
+
+        assert_eq!(eui.eui(), 0xf0debc9a78563412);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ impl<SPI> DW1000<SPI> where SPI: SpimExt {
 }
 
 
-/// The device identifier (DEV_ID)
+/// Device identifier - includes device type and revision info
 #[allow(non_camel_case_types)]
 pub struct DEV_ID([u8; 5]);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,34 +47,65 @@ impl<SPI> DW1000<SPI> where SPI: SpimExt {
 
     /// Read the device identifier (DEV_ID)
     pub fn dev_id(&mut self) -> Result<DEV_ID, spim::Error> {
-        // Set up the transmit buffer
-        //
-        // It consists of only one byte for the transaction header. Since this
-        // is a read operation, there is no transaction body.
         let header =
-            (0 & 0x80) |  // read
-            (0 & 0x40) |  // no sub-index
-            (0 & 0x3f);   // index of DEV_ID register
+            (0          & 0x80) |  // read
+            (0          & 0x40) |  // no sub-index
+            (DEV_ID::ID & 0x3f);   // index of DEV_ID register
         let tx_buffer = [header];
 
-        // Set up the receive buffer
-        //
-        // SPI is a synchronous interface, so we're going to receive a byte for
-        // every one we send. That means in addition to the 4 bytes we actually
-        // expect, we need an additional one that we receive while we send the
-        // header.
-        let mut rx_buffer = [0u8; 5];
+        let mut r = DEV_ID::new();
 
-        self.spim.read(&mut self.chip_select, &tx_buffer, &mut rx_buffer)?;
+        self.spim.read(&mut self.chip_select, &tx_buffer, r.rx_buffer())?;
 
-        Ok(DEV_ID(rx_buffer))
+        Ok(r)
     }
+}
+
+
+/// Implemented for all registers
+///
+/// This trait is for internal use only. Users of this library should never need
+/// to implement this trait, nor use its associated items.
+///
+/// The DW1000 user manual, section 7.1, specifies what the values of those
+/// constant should be for each register.
+pub trait Register {
+    /// The register ID
+    const ID:  u8;
+
+    /// The lenght of the register
+    const LEN: usize;
+
+    /// Creates an instance of the register
+    fn new() -> Self;
+
+    /// Returns a mutable reference to the register's internal buffer
+    ///
+    /// SPI is a synchronous interface, which means a bytes is received for
+    /// every byte that is sent, even though the bytes we receive while sending
+    /// something end up being ignored. Still, we need room for those bytes in
+    /// the buffer, so the length of the buffer must be equal to the length of
+    /// the register plus the length of the transaction header.
+    fn rx_buffer(&mut self) -> &mut [u8];
 }
 
 
 /// Device identifier - includes device type and revision info
 #[allow(non_camel_case_types)]
 pub struct DEV_ID([u8; 5]);
+
+impl Register for DEV_ID {
+    const ID:  u8    = 0x00;
+    const LEN: usize = 4;
+
+    fn new() -> Self {
+        DEV_ID([0; 5])
+    }
+
+    fn rx_buffer(&mut self) -> &mut [u8] {
+        &mut self.0
+    }
+}
 
 impl DEV_ID {
     /// Register Identification Tag

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,13 +51,11 @@ impl<SPI> DW1000<SPI> where SPI: SpimExt {
         //
         // It consists of only one byte for the transaction header. Since this
         // is a read operation, there is no transaction body.
-        //
-        // The transaction signals a read without a sub-index, which means it's
-        // one byte long. This byte consists of the following bits:
-        //   7: 0 for read
-        //   6: 0 for no sub-index
-        // 5-0: 0 for DEV_ID register
-        let tx_buffer = [0u8];
+        let header =
+            (0 & 0x80) |  // read
+            (0 & 0x40) |  // no sub-index
+            (0 & 0x3f);   // index of DEV_ID register
+        let tx_buffer = [header];
 
         // Set up the receive buffer
         //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ impl<SPI> DW1000<SPI> where SPI: SpimExt {
     }
 
     /// Read the device identifier (DEV_ID)
-    pub fn dev_id(&mut self) -> Result<DevId, spim::Error> {
+    pub fn dev_id(&mut self) -> Result<DEV_ID, spim::Error> {
         // Set up the transmit buffer
         //
         // It consists of only one byte for the transaction header. Since this
@@ -69,15 +69,16 @@ impl<SPI> DW1000<SPI> where SPI: SpimExt {
 
         self.spim.read(&mut self.chip_select, &tx_buffer, &mut rx_buffer)?;
 
-        Ok(DevId(rx_buffer))
+        Ok(DEV_ID(rx_buffer))
     }
 }
 
 
 /// The device identifier (DEV_ID)
-pub struct DevId([u8; 5]);
+#[allow(non_camel_case_types)]
+pub struct DEV_ID([u8; 5]);
 
-impl DevId {
+impl DEV_ID {
     /// Register Identification Tag
     pub fn ridtag(&self) -> u16 {
         ((self.0[4] as u16) << 8) | self.0[3] as u16
@@ -102,12 +103,12 @@ impl DevId {
 
 #[cfg(test)]
 mod tests {
-    use super::DevId;
+    use super::DEV_ID;
 
 
     #[test]
     fn dev_id_should_provide_access_to_its_fields() {
-        let dev_id = DevId([0x00, 0x30, 0x01, 0xca, 0xde]);
+        let dev_id = DEV_ID([0x00, 0x30, 0x01, 0xca, 0xde]);
 
         assert_eq!(dev_id.rev()   , 0     );
         assert_eq!(dev_id.ver()   , 3     );


### PR DESCRIPTION
Replaces the `dev_id` function with a generic `read` function that can read from any register that implements the new `Register` trait. This makes it possible to support many more registers with minimal effort, although it's probably not enough to support all registers.

There's this notion of a sub-index in the transaction header. I'm not sure how it works and which registers need it, but I'm pretty sure the `read` method will need to support it eventually. Still, this is a good first step.