### PR TITLE
Fix Travis build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ authors = ["Hanno Braun <hanno@braun-robotics.com>"]
 # embedded-hal instead. Unfortunately nrf52-hal doesn't implement the SPI traits
 # of embedded-hal yet, and we need nRF52 support because it's used on the
 # DWM1001 board.
-nrf52-hal = { git = "https://github.com/braun-robotics/nrf52-hal.git" }
+nrf52-hal = { git = "https://github.com/braun-robotics/nrf52-hal.git", default-features = false }


### PR DESCRIPTION
The latest cortex-m-rt release has upped its minimum required Rust
version to 1.30-beta. This broke the build for this crate, except on
nightly.

Fortunately we don't actually need cortex-m-rt. It was pulled in by
default via nrf52-hal. This fixes the problem by disabling nrf52-hal's
default features.