### PR TITLE
Add support for sub-registers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,10 @@ fn init_header<R: Register>(write: bool, buffer: &mut [u8]) -> usize {
 /// constant should be for each register.
 pub trait Register {
     /// The register index
-    const ID:  u8;
+    const ID: u8;
+
+    /// The registers's sub-index
+    const SUB_ID: u16;
 
     /// The lenght of the register
     const LEN: usize;
@@ -158,6 +161,7 @@ macro_rules! impl_register {
     (
         $(
             $id:expr,
+            $sub_id:expr,
             $len:expr,
             $rw:tt,
             $name:ident($name_lower:ident) {
@@ -178,8 +182,9 @@ macro_rules! impl_register {
             pub struct $name;
 
             impl Register for $name {
-                const ID:  u8    = $id;
-                const LEN: usize = $len;
+                const ID:     u8    = $id;
+                const SUB_ID: u16   = $sub_id;
+                const LEN:    usize = $len;
             }
 
             #[$doc]
@@ -426,20 +431,20 @@ macro_rules! impl_rw {
 }
 
 impl_register! {
-    0x00, 4, RO, DEV_ID(dev_id) { /// Device identifier
+    0x00, 0x00, 4, RO, DEV_ID(dev_id) { /// Device identifier
         rev,     0,  3, u8;  /// Revision
         ver,     4,  7, u8;  /// Version
         model,   8, 15, u8;  /// Model
         ridtag, 16, 31, u16; /// Register Identification Tag
     }
-    0x01, 8, RW, EUI(eui) { /// Extended Unique Identifier
+    0x01, 0x00, 8, RW, EUI(eui) { /// Extended Unique Identifier
         eui, 0, 63, u64; /// Extended Unique Identifier
     }
-    0x03, 4, RW, PANADR(panadr) { /// PAN Identifier and Short Address
+    0x03, 0x00, 4, RW, PANADR(panadr) { /// PAN Identifier and Short Address
         short_addr,  0, 15, u16; /// Short Address
         pan_id,     16, 31, u16; /// PAN Identifier
     }
-    0x08, 5, RW, TX_FCTRL(tx_fctrl) { /// TX Frame Control
+    0x08, 0x00, 5, RW, TX_FCTRL(tx_fctrl) { /// TX Frame Control
         tflen,     0,  6, u8;  /// TX Frame Length
         tfle,      7,  9, u8;  /// TX Frame Length Extension
         txbr,     13, 14, u8;  /// TX Bit Rate
@@ -450,7 +455,7 @@ impl_register! {
         txboffs,  22, 31, u16; /// TX Buffer Index Offset
         ifsdelay, 32, 39, u8;  /// Inter-Frame Spacing
     }
-    0x0D, 4, RW, SYS_CTRL(sys_ctrl) { /// System Control Register
+    0x0D, 0x00, 4, RW, SYS_CTRL(sys_ctrl) { /// System Control Register
         sfcst,      0,  0, u8; /// Suppress Auto-FCS Transmission
         txstrt,     1,  1, u8; /// Transmit Start
         txdlys,     2,  2, u8; /// Transmitter Delayed Sending
@@ -461,7 +466,7 @@ impl_register! {
         rxdlye,     9,  9, u8; /// Receiver Delayed Enable
         hrbpt,     24, 24, u8; /// Host Side RX Buffer Pointer Toggle
     }
-    0x0F, 5, RW, SYS_STATUS(sys_status) { /// System Event Status Register
+    0x0F, 0x00, 5, RW, SYS_STATUS(sys_status) { /// System Event Status Register
         irqs,       0,  0, u8; /// Interrupt Request Status
         cplock,     1,  1, u8; /// Clock PLL Lock
         esyncr,     2,  2, u8; /// External Sync Clock Reset
@@ -508,8 +513,9 @@ impl_register! {
 pub struct TX_BUFFER;
 
 impl Register for TX_BUFFER {
-    const ID:  u8    = 0x09;
-    const LEN: usize = 127;
+    const ID:     u8    = 0x09;
+    const SUB_ID: u16   = 0x00;
+    const LEN:    usize = 127;
 }
 
 impl Writable for TX_BUFFER {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ impl<SPI> DW1000<SPI> where SPI: SpimExt {
             R: Register + Readable,
     {
         let mut tx_buffer = [0; 1];
-        make_header::<R>(false, &mut tx_buffer);
+        init_header::<R>(false, &mut tx_buffer);
 
         let mut r = R::read();
 
@@ -73,7 +73,7 @@ impl<SPI> DW1000<SPI> where SPI: SpimExt {
         let mut w = R::write();
         f(&mut w);
         let tx_buffer = R::buffer(&mut w);
-        make_header::<R>(true, tx_buffer);
+        init_header::<R>(true, tx_buffer);
 
         self.spim.write(&mut self.chip_select, &tx_buffer)?;
 
@@ -96,7 +96,7 @@ impl<SPI> DW1000<SPI> where SPI: SpimExt {
         f(&mut r, &mut w);
 
         let tx_buffer = <R as Writable>::buffer(&mut w);
-        make_header::<R>(true, tx_buffer);
+        init_header::<R>(true, tx_buffer);
 
         self.spim.write(&mut self.chip_select, &tx_buffer)?;
 
@@ -106,7 +106,7 @@ impl<SPI> DW1000<SPI> where SPI: SpimExt {
 
 
 /// Initializes the header for a register in the given buffer
-fn make_header<R: Register>(write: bool, buffer: &mut [u8]) {
+fn init_header<R: Register>(write: bool, buffer: &mut [u8]) {
     buffer[0] =
         ((write as u8) << 7 & 0x80) |
         (0             << 6 & 0x40) |  // no sub-index

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -426,76 +426,76 @@ macro_rules! impl_rw {
 }
 
 impl_register! {
-    0x00, 4, RO, DEV_ID(dev_id) {         /// Device identifier
-        rev,     0,  3, u8;               /// Revision
-        ver,     4,  7, u8;               /// Version
-        model,   8, 15, u8;               /// Model
-        ridtag, 16, 31, u16;              /// Register Identification Tag
+    0x00, 4, RO, DEV_ID(dev_id) { /// Device identifier
+        rev,     0,  3, u8;  /// Revision
+        ver,     4,  7, u8;  /// Version
+        model,   8, 15, u8;  /// Model
+        ridtag, 16, 31, u16; /// Register Identification Tag
     }
-    0x01, 8, RW, EUI(eui) {               /// Extended Unique Identifier
-        eui, 0, 63, u64;                  /// Extended Unique Identifier
+    0x01, 8, RW, EUI(eui) { /// Extended Unique Identifier
+        eui, 0, 63, u64; /// Extended Unique Identifier
     }
-    0x03, 4, RW, PANADR(panadr) {         /// PAN Identifier and Short Address
-        short_addr,  0, 15, u16;          /// Short Address
-        pan_id,     16, 31, u16;          /// PAN Identifier
+    0x03, 4, RW, PANADR(panadr) { /// PAN Identifier and Short Address
+        short_addr,  0, 15, u16; /// Short Address
+        pan_id,     16, 31, u16; /// PAN Identifier
     }
-    0x08, 5, RW, TX_FCTRL(tx_fctrl) {     /// TX Frame Control
-        tflen,     0,  6, u8;             /// TX Frame Length
-        tfle,      7,  9, u8;             /// TX Frame Length Extension
-        txbr,     13, 14, u8;             /// TX Bit Rate
-        tr,       15, 15, u8;             /// TX Ranging Enable
-        txprf,    16, 17, u8;             /// TX Pulse Repetition Frequency
-        txpsr,    18, 19, u8;             /// TX Preamble Symbol Repetitions
-        pe,       20, 21, u8;             /// Preamble Extension
-        txboffs,  22, 31, u16;            /// TX Buffer Index Offset
-        ifsdelay, 32, 39, u8;             /// Inter-Frame Spacing
+    0x08, 5, RW, TX_FCTRL(tx_fctrl) { /// TX Frame Control
+        tflen,     0,  6, u8;  /// TX Frame Length
+        tfle,      7,  9, u8;  /// TX Frame Length Extension
+        txbr,     13, 14, u8;  /// TX Bit Rate
+        tr,       15, 15, u8;  /// TX Ranging Enable
+        txprf,    16, 17, u8;  /// TX Pulse Repetition Frequency
+        txpsr,    18, 19, u8;  /// TX Preamble Symbol Repetitions
+        pe,       20, 21, u8;  /// Preamble Extension
+        txboffs,  22, 31, u16; /// TX Buffer Index Offset
+        ifsdelay, 32, 39, u8;  /// Inter-Frame Spacing
     }
-    0x0D, 4, RW, SYS_CTRL(sys_ctrl) {     /// System Control Register
-        sfcst,      0,  0, u8;            /// Suppress Auto-FCS Transmission
-        txstrt,     1,  1, u8;            /// Transmit Start
-        txdlys,     2,  2, u8;            /// Transmitter Delayed Sending
-        cansfcs,    3,  3, u8;            /// Cancel Auto-FCS Suppression
-        trxoff,     6,  6, u8;            /// Transceiver Off
-        wait4resp,  7,  7, u8;            /// Wait for Response
-        rxenab,     8,  8, u8;            /// Enable Receiver
-        rxdlye,     9,  9, u8;            /// Receiver Delayed Enable
-        hrbpt,     24, 24, u8;            /// Host Side RX Buffer Pointer Toggle
+    0x0D, 4, RW, SYS_CTRL(sys_ctrl) { /// System Control Register
+        sfcst,      0,  0, u8; /// Suppress Auto-FCS Transmission
+        txstrt,     1,  1, u8; /// Transmit Start
+        txdlys,     2,  2, u8; /// Transmitter Delayed Sending
+        cansfcs,    3,  3, u8; /// Cancel Auto-FCS Suppression
+        trxoff,     6,  6, u8; /// Transceiver Off
+        wait4resp,  7,  7, u8; /// Wait for Response
+        rxenab,     8,  8, u8; /// Enable Receiver
+        rxdlye,     9,  9, u8; /// Receiver Delayed Enable
+        hrbpt,     24, 24, u8; /// Host Side RX Buffer Pointer Toggle
     }
     0x0F, 5, RW, SYS_STATUS(sys_status) { /// System Event Status Register
-        irqs,       0,  0, u8;            /// Interrupt Request Status
-        cplock,     1,  1, u8;            /// Clock PLL Lock
-        esyncr,     2,  2, u8;            /// External Sync Clock Reset
-        aat,        3,  3, u8;            /// Automatic Acknowledge Trigger
-        txfrb,      4,  4, u8;            /// TX Frame Begins
-        txprs,      5,  5, u8;            /// TX Preamble Sent
-        txphs,      6,  6, u8;            /// TX PHY Header Sent
-        txfrs,      7,  7, u8;            /// TX Frame Sent
-        rxprd,      8,  8, u8;            /// RX Preamble Detected
-        rxsfdd,     9,  9, u8;            /// RX SFD Detected
-        ldedone,   10, 10, u8;            /// LDE Processing Done
-        rxphd,     11, 11, u8;            /// RX PHY Header Detect
-        rxphe,     12, 12, u8;            /// RX PHY Header Error
-        rxdfr,     13, 13, u8;            /// RX Data Frame Ready
-        rxfcg,     14, 14, u8;            /// RX FCS Good
-        rxfce,     15, 15, u8;            /// RX FCS Error
-        rxrfsl,    16, 16, u8;            /// RX Reed-Solomon Frame Sync Loss
-        rxrfto,    17, 17, u8;            /// RX Frame Wait Timeout
-        ldeerr,    18, 18, u8;            /// Leading Edge Detection Error
-        rxovrr,    20, 20, u8;            /// RX Overrun
-        rxpto,     21, 21, u8;            /// Preamble Detection Timeout
-        gpioirq,   22, 22, u8;            /// GPIO Interrupt
-        slp2init,  23, 23, u8;            /// SLEEP to INIT
-        rfpll_ll,  24, 24, u8;            /// RF PLL Losing Lock
-        clkpll_ll, 25, 25, u8;            /// Clock PLL Losing Lock
-        rxsfdto,   26, 26, u8;            /// Receive SFD Timeout
-        hpdwarn,   27, 27, u8;            /// Half Period Delay Warning
-        txberr,    28, 28, u8;            /// TX Buffer Error
-        affrej,    29, 29, u8;            /// Auto Frame Filtering Rejection
-        hsrbp,     30, 30, u8;            /// Host Side RX Buffer Pointer
-        icrbp,     31, 31, u8;            /// IC Side RX Buffer Pointer
-        rxrscs,    32, 32, u8;            /// RX Reed-Solomon Correction Status
-        rxprej,    33, 33, u8;            /// RX Preamble Rejection
-        txpute,    34, 34, u8;            /// TX Power Up Time Error
+        irqs,       0,  0, u8; /// Interrupt Request Status
+        cplock,     1,  1, u8; /// Clock PLL Lock
+        esyncr,     2,  2, u8; /// External Sync Clock Reset
+        aat,        3,  3, u8; /// Automatic Acknowledge Trigger
+        txfrb,      4,  4, u8; /// TX Frame Begins
+        txprs,      5,  5, u8; /// TX Preamble Sent
+        txphs,      6,  6, u8; /// TX PHY Header Sent
+        txfrs,      7,  7, u8; /// TX Frame Sent
+        rxprd,      8,  8, u8; /// RX Preamble Detected
+        rxsfdd,     9,  9, u8; /// RX SFD Detected
+        ldedone,   10, 10, u8; /// LDE Processing Done
+        rxphd,     11, 11, u8; /// RX PHY Header Detect
+        rxphe,     12, 12, u8; /// RX PHY Header Error
+        rxdfr,     13, 13, u8; /// RX Data Frame Ready
+        rxfcg,     14, 14, u8; /// RX FCS Good
+        rxfce,     15, 15, u8; /// RX FCS Error
+        rxrfsl,    16, 16, u8; /// RX Reed-Solomon Frame Sync Loss
+        rxrfto,    17, 17, u8; /// RX Frame Wait Timeout
+        ldeerr,    18, 18, u8; /// Leading Edge Detection Error
+        rxovrr,    20, 20, u8; /// RX Overrun
+        rxpto,     21, 21, u8; /// Preamble Detection Timeout
+        gpioirq,   22, 22, u8; /// GPIO Interrupt
+        slp2init,  23, 23, u8; /// SLEEP to INIT
+        rfpll_ll,  24, 24, u8; /// RF PLL Losing Lock
+        clkpll_ll, 25, 25, u8; /// Clock PLL Losing Lock
+        rxsfdto,   26, 26, u8; /// Receive SFD Timeout
+        hpdwarn,   27, 27, u8; /// Half Period Delay Warning
+        txberr,    28, 28, u8; /// TX Buffer Error
+        affrej,    29, 29, u8; /// Auto Frame Filtering Rejection
+        hsrbp,     30, 30, u8; /// Host Side RX Buffer Pointer
+        icrbp,     31, 31, u8; /// IC Side RX Buffer Pointer
+        rxrscs,    32, 32, u8; /// RX Reed-Solomon Correction Status
+        rxprej,    33, 33, u8; /// RX Preamble Rejection
+        txpute,    34, 34, u8; /// TX Power Up Time Error
     }
 }
 


### PR DESCRIPTION
Adds support for sub-registers (registers that can only be accessed with a sub-index) by extending the register definition macro syntax and updating all code that touches headers to support any header size.

This pull request only contains changes to infrastructure, but I have local code (coming soon) that adds support for sub-registers and tests that all of this actually work.