### PR TITLE
Fix default configuration

### DIFF
--- a/src/hl.rs
+++ b/src/hl.rs
@@ -238,10 +238,6 @@ impl<SPI> DW1000<SPI, Ready> where SPI: SpimExt {
                     .clkpll_ll(0b1)
             )?;
 
-        // If we cared about MAC addresses, which we don't in this example, we'd
-        // have to enable frame filtering at this point. By default it's off,
-        // meaning we'll receive everything, no matter who it is addressed to.
-
         // We're expecting a preamble length of `64`. Set PAC size to the
         // recommended value for that preamble length, according to section
         // 4.1.1. The value we're writing to DRX_TUNE2 here also depends on the

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -49,14 +49,83 @@ impl<SPI> DW1000<SPI, Uninitialized> where SPI: SpimExt {
     }
 
     /// Initialize the DW1000
-    pub fn init(self) -> DW1000<SPI, Ready> {
-        // Nothing here yet.
+    ///
+    /// The DW1000's default configuration is somewhat inconsistent, and the
+    /// user manual (section 2.5.5) has a long list of default configuration
+    /// values that should be changed to guarantee everything works correctly.
+    /// This method does just that.
+    ///
+    /// Please note that this method assumes that you kept the default
+    /// configuration. It is generally recommended not to change configuration
+    /// before calling this method.
+    pub fn init(mut self) -> Result<DW1000<SPI, Ready>, Error> {
+        // Set AGC_TUNE1. See user manual, section 2.5.5.1.
+        self.ll.agc_tune1().write(|w| w.value(0x8870))?;
 
-        DW1000 {
+        // Set AGC_TUNE2. See user manual, section 2.5.5.2.
+        self.ll.agc_tune2().write(|w| w.value(0x2502A907))?;
+
+        // Set DRX_TUNE2. See user manual, section 2.5.5.3.
+        self.ll.drx_tune2().write(|w| w.value(0x311A002D))?;
+
+        // Set NTM. See user manual, section 2.5.5.4. This improves performance
+        // in line-of-sight conditions, but might not be the best choice if non-
+        // line-of-sight performance is important.
+        self.ll.lde_cfg1().modify(|_, w| w.ntm(0xD))?;
+
+        // Set LDE_CFG2. See user manual, section 2.5.5.5.
+        self.ll.lde_cfg2().write(|w| w.value(0x1607))?;
+
+        // Set TX_POWER. See user manual, section 2.5.5.6.
+        self.ll.tx_power().write(|w| w.value(0x0E082848))?;
+
+        // Set RF_TXCTRL. See user manual, section 2.5.5.7.
+        self.ll.rf_txctrl().modify(|_, w|
+            w
+                .txmtune(0b1111)
+                .txmq(0b111)
+        )?;
+
+        // Set TC_PGDELAY. See user manual, section 2.5.5.8.
+        self.ll.tc_pgdelay().write(|w| w.value(0xC0))?;
+
+        // Set FS_PLLTUNE. See user manual, section 2.5.5.9.
+        self.ll.fs_plltune().write(|w| w.value(0xBE))?;
+
+        // Set LDELOAD. See user manual, section 2.5.5.10.
+        self.ll.pmsc_ctrl0().modify(|_, w| w.sysclks(0b01))?;
+        self.ll.otp_ctrl().modify(|_, w| w.ldeload(0b1))?;
+        while self.ll.otp_ctrl().read()?.ldeload() == 0b1 {}
+        self.ll.pmsc_ctrl0().modify(|_, w| w.sysclks(0b00))?;
+
+        // Set LDOTUNE. See user manual, section 2.5.5.11.
+        self.ll.otp_addr().write(|w| w.value(0x004))?;
+        self.ll.otp_ctrl().modify(|_, w|
+            w
+                .otprden(0b1)
+                .otpread(0b1)
+        )?;
+        while self.ll.otp_ctrl().read()?.otpread() == 0b1 {}
+        let ldotune_low = self.ll.otp_rdat().read()?.value();
+        if ldotune_low != 0 {
+            self.ll.otp_addr().write(|w| w.value(0x005))?;
+            self.ll.otp_ctrl().modify(|_, w|
+                w
+                    .otprden(0b1)
+                    .otpread(0b1)
+            )?;
+            while self.ll.otp_ctrl().read()?.otpread() == 0b1 {}
+            let ldotune_high = self.ll.otp_rdat().read()?.value();
+
+            let ldotune = ldotune_low as u64 | (ldotune_high as u64) << 32;
+            self.ll.ldotune().write(|w| w.value(ldotune))?;
+        }
+
+        Ok(DW1000 {
             ll:     self.ll,
             seq:    self.seq,
             _state: Ready,
-        }
+        })
     }
 }
 

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -30,7 +30,7 @@ pub struct DW1000<SPI, State> {
     _state: State,
 }
 
-impl<SPI> DW1000<SPI, Ready> where SPI: SpimExt {
+impl<SPI> DW1000<SPI, Uninitialized> where SPI: SpimExt {
     /// Create a new instance of `DW1000`
     ///
     /// Requires the SPI peripheral and the chip select pin that are connected
@@ -44,10 +44,23 @@ impl<SPI> DW1000<SPI, Ready> where SPI: SpimExt {
         DW1000 {
             ll:     ll::DW1000::new(spim, chip_select),
             seq:    Wrapping(0),
-            _state: Ready,
+            _state: Uninitialized,
         }
     }
 
+    /// Initialize the DW1000
+    pub fn init(self) -> DW1000<SPI, Ready> {
+        // Nothing here yet.
+
+        DW1000 {
+            ll:     self.ll,
+            seq:    self.seq,
+            _state: Ready,
+        }
+    }
+}
+
+impl<SPI> DW1000<SPI, Ready> where SPI: SpimExt {
     /// Sets the network id and address used for sending and receiving
     pub fn set_address(&mut self, address: mac::Address)
         -> Result<(), Error>
@@ -496,6 +509,10 @@ impl From<Error> for nb::Error<Error> {
     }
 }
 
+
+
+/// Indicates that the `DW1000` instance is not initialized yet
+pub struct Uninitialized;
 
 /// Indicates that the `DW1000` instance is ready to be used
 pub struct Ready;

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -147,18 +147,12 @@ impl<SPI> DW1000<SPI, Ready> where SPI: SpimExt {
             })?;
         self.ll
             .tx_fctrl()
-            .write(|w| {
+            .modify(|_, w| {
                 let tflen = len as u8 + 2;
                 w
                     .tflen(tflen) // data length + two-octet CRC
                     .tfle(0)      // no non-standard length extension
-                    .txbr(0b01)   // 850 kbps bit rate
-                    .tr(0b0)      // no ranging
-                    .txprf(0b01)  // pulse repetition frequency: 16 MHz
-                    .txpsr(0b01)  // preamble length: 64
-                    .pe(0b00)     // no non-standard preamble length
                     .txboffs(0)   // no offset in TX_BUFFER
-                    .ifsdelay(0)  // no delay between frames
             })?;
 
         // Start transmission

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -162,7 +162,7 @@ impl<SPI> DW1000<SPI> where SPI: SpimExt {
         Ok(TxFuture(self))
     }
 
-    /// Starts the receiver
+    /// Attempt to receive a frame
     pub fn receive(&mut self) -> Result<RxFuture<SPI>, Error> {
         // For unknown reasons, the DW1000 gets stuck in RX mode without ever
         // receiving anything, after receiving one good frame. Reset the

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -301,17 +301,6 @@ impl<SPI> DW1000<SPI, Ready> where SPI: SpimExt {
                     .clkpll_ll(0b1)
             )?;
 
-        // We're expecting a preamble length of `64`. Set PAC size to the
-        // recommended value for that preamble length, according to section
-        // 4.1.1. The value we're writing to DRX_TUNE2 here also depends on the
-        // PRF, which we expect to be 16 MHz.
-        self.ll
-            .drx_tune2()
-            .write(|w|
-                // PAC size 8, with 16 MHz PRF
-                w.value(0x311A002D)
-            )?;
-
         // If we were going to receive at 110 kbps, we'd need to set the RXM110K
         // bit in the System Configuration register. We're expecting to receive
         // at 850 kbps though, so the default is fine. See section 4.1.3 for a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,4 +21,6 @@ pub use ieee802154::mac;
 pub use hl::{
     DW1000,
     Error,
+    Ready,
+    Uninitialized,
 };


### PR DESCRIPTION
The DW1000's default configuration is inconsistent, and some aspects of it need to be changed before everything can work correctly. I added comments to the code that explain more details about this.

This should have been there from the beginning, but I didn't know about it. Everything worked well enough. I finally ran into a problem related to ranging that led me to discover that section in the user manual.

Based on my highly objection measurement technique, "looking at blinking status LEDs", it seems that this PR also improves the reliability of existing code.