### PR TITLE
Extend high-level API to prepare for ranging implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,3 +25,7 @@ pub use hl::{
     Ready,
     Uninitialized,
 };
+
+
+/// The maximum value of 40-bit system time stamps.
+pub const TIME_MAX: u64 = 0xffffffffff;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ extern crate nrf52832_hal as hal;
 
 pub mod ll;
 pub mod hl;
+pub mod util;
 
 
 pub use ieee802154::mac;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub use ieee802154::mac;
 pub use hl::{
     DW1000,
     Error,
+    Message,
     Ready,
     Uninitialized,
 };

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,25 @@
+//! Contains utility functions that are useful when working with the DW1000
+
+
+use TIME_MAX;
+
+
+/// Determines the duration between to time stamps
+///
+/// Expects two 40-bit system time stamps and returns the duration between the
+/// two, taking potential overflow into account.
+///
+/// # Panics
+///
+/// Panics, if the time stamps passed don't fit within 40 bits.
+pub fn duration_between(earlier: u64, later: u64) -> u64 {
+    assert!(earlier <= TIME_MAX);
+    assert!(later   <= TIME_MAX);
+
+    if later >= earlier {
+        later - earlier
+    }
+    else {
+        TIME_MAX - earlier + later + 1
+    }
+}


### PR DESCRIPTION
Extends the high-level API with features that are useful for implementing ranging. This upstreams some of the working parts of my local mostly-not-working ranging code.