### PR TITLE
Add utility macros that can help manage this API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,8 @@
 
 extern crate ieee802154;
 extern crate nb;
-extern crate nrf52832_hal as hal;
+
+pub extern crate nrf52832_hal as hal;
 
 
 pub mod ll;

--- a/src/util.rs
+++ b/src/util.rs
@@ -23,3 +23,49 @@ pub fn duration_between(earlier: u64, later: u64) -> u64 {
         TIME_MAX - earlier + later + 1
     }
 }
+
+
+/// Blocks on a non-blocking operation until a timer times out
+///
+/// Expects two arguments: A timer, and an expression that evaluates to
+/// `nb::Result<T, E>` and returns `Result<T, TimeoutError<E>>`.
+#[macro_export]
+macro_rules! block_timeout {
+    ($timer:expr, $op:expr) => {
+        {
+            use $crate::hal::prelude::TimerExt;
+            let timer: &mut $crate::hal::Timer<_> = $timer;
+
+            loop {
+                match timer.wait() {
+                    Ok(()) =>
+                        break Err($crate::util::TimeoutError::Timeout),
+                    Err(nb::Error::WouldBlock) =>
+                        (),
+                    Err(_) =>
+                        unreachable!(),
+                }
+
+                match $op {
+                    Ok(result) =>
+                        break Ok(result),
+                    Err(nb::Error::WouldBlock) =>
+                        (),
+                    Err(nb::Error::Other(error)) =>
+                        break Err($crate::util::TimeoutError::Other(error)),
+                }
+            }
+        }
+    }
+}
+
+
+/// An error that can be a timeout or another error
+#[derive(Debug)]
+pub enum TimeoutError<T> {
+    /// The operation timed out
+    Timeout,
+
+    /// Another error occured
+    Other(T),
+}


### PR DESCRIPTION
This driver provides a non-blocking API. In addition, the DW1000 is a half-duplex system, so the user has to manage switching between transmitting and receiving as appropriate.

All of this is not quite trivial, and requires the handling of timeouts and such. These macros alleviate that somewhat, making this task a bit easier.

I don't intend this to be *the* solution for this problem, but it's a good way to handle these things in straight-forward applications that don't require anything special. A better solution to the problem would probably be something that can manage asynchronous tasks, like RTFM maybe.