### PR TITLE
Take TX antenna delay into account for range measurement

### DIFF
--- a/src/hl.rs
+++ b/src/hl.rs
@@ -146,6 +146,12 @@ impl<SPI> DW1000<SPI, Ready> where SPI: SpimExt {
         Ok(())
     }
 
+    /// Returns the TX antenna delay
+    pub fn get_tx_antenna_delay(&mut self) -> Result<Duration, Error> {
+        let tx_antenna_delay = self.ll.tx_antd().read()?.value();
+        Ok(Duration(tx_antenna_delay as u64))
+    }
+
     /// Sets the network id and address used for sending and receiving
     pub fn set_address(&mut self, address: mac::Address)
         -> Result<(), Error>

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -5,7 +5,10 @@
 //! greater flexibility provided by the register-level interface.
 
 
-use core::num::Wrapping;
+use core::{
+    num::Wrapping,
+    ops::Add,
+};
 
 use hal::{
     prelude::*,
@@ -662,11 +665,27 @@ pub struct Message<'l> {
 
 
 /// An instant, in DW1000 system time
+///
+/// DW1000 timestamps are 40-bit numbers. Creating an `Instant` with a value
+/// larger than 2^40 - 1 can lead to undefined behavior.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[repr(C)]
 pub struct Instant(pub u64);
 
 /// A duration between two DW1000 system time instants
+///
+/// DW1000 timestamps are 40-bit numbers. Creating a `Duration` with a value
+/// larger than 2^40 - 1 can lead to undefined behavior.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[repr(C)]
 pub struct Duration(pub u64);
+
+impl Add<Duration> for Instant {
+    type Output = Instant;
+
+    fn add(self, rhs: Duration) -> Self::Output {
+        // Both `Instant` and `Duration` contain 40-bit numbers, so this
+        // addition should never overflow.
+        Instant((self.0 + rhs.0) % (TIME_MAX + 1))
+    }
+}

--- a/src/ranging.rs
+++ b/src/ranging.rs
@@ -37,6 +37,7 @@ use serde::{
 use ssmarshal;
 
 use ::{
+    hl,
     mac,
     util,
     Duration,
@@ -100,13 +101,13 @@ pub trait Message: Sized {
     }
 
     /// Decodes a received message of this type
-    fn decode(buf: &[u8]) -> Result<Option<Self::Data>, Error> {
-        if !buf.starts_with(Self::PRELUDE.0) {
+    fn decode(message: &hl::Message) -> Result<Option<Self::Data>, Error> {
+        if !message.frame.payload.starts_with(Self::PRELUDE.0) {
             // Not a request of this type
             return Ok(None);
         }
 
-        if buf.len() != Self::LEN {
+        if message.frame.payload.len() != Self::LEN {
             // Invalid request
             return Err(Error::BufferTooSmall {
                 required_len: Self::LEN,
@@ -115,7 +116,7 @@ pub trait Message: Sized {
 
         // The request passes muster. Let's decode it.
         let (message, _) = ssmarshal::deserialize(
-            &buf[Self::PRELUDE.0.len()..
+            &message.frame.payload[Self::PRELUDE.0.len()..
         ])?;
 
         Ok(Some(message))

--- a/src/ranging.rs
+++ b/src/ranging.rs
@@ -49,6 +49,14 @@ use ::{
 };
 
 
+/// The transmission delay
+///
+/// This defines the transmission delay as 10 ms. This should be enough to
+/// finish the rest of the preparation and send the message, even if we're
+/// running with unoptimized code.
+const TX_DELAY: u32 = 10_000_000;
+
+
 /// A ranging message
 pub trait Message: Sized {
     /// A prelude that identifies the message
@@ -166,7 +174,7 @@ impl Ping {
         where SPI: SpimExt
     {
         Ok(Ping {
-            ping_tx_time: dw1000.time_from_delay(10_000_000)?,
+            ping_tx_time: dw1000.time_from_delay(TX_DELAY)?,
         })
     }
 }
@@ -224,7 +232,7 @@ impl Request {
         -> Result<Self, Error>
         where SPI: SpimExt
     {
-        let request_tx_time = dw1000.time_from_delay(10_000_000)?;
+        let request_tx_time = dw1000.time_from_delay(TX_DELAY)?;
 
         let ping_reply_time = util::duration_between(
             ping.rx_time,
@@ -300,7 +308,7 @@ impl Response {
         -> Result<Self, Error>
         where SPI: SpimExt
     {
-        let response_tx_time = dw1000.time_from_delay(10_000_000)?;
+        let response_tx_time = dw1000.time_from_delay(TX_DELAY)?;
 
         let ping_round_trip_time = util::duration_between(
             request.data.ping_tx_time,

--- a/src/ranging.rs
+++ b/src/ranging.rs
@@ -285,7 +285,7 @@ impl Response {
         -> Result<Self, Error>
         where SPI: SpimExt
     {
-        let tx_time = dw1000.time_from_delay(10_000_000)?;
+        let response_tx_time = dw1000.time_from_delay(10_000_000)?;
 
         let ping_round_trip_time = util::duration_between(
             ping_tx_time,
@@ -293,7 +293,7 @@ impl Response {
         );
         let request_reply_time = util::duration_between(
             request_rx_time,
-            tx_time,
+            response_tx_time,
         );
 
         let data = ResponseData {
@@ -305,7 +305,7 @@ impl Response {
 
         Ok(Response {
             recipient,
-            tx_time,
+            tx_time: response_tx_time,
             data,
         })
     }


### PR DESCRIPTION
This pull request contains quite a few cleanup commits that I made while searching for error sources in the range measurement, but the meat is in the last few commits that change the range calculation to take the antenna delay into account.

This greatly improves the accuracy of the measurement, bringing it into a range where it starts being useful.