### PR TITLE
Don't store borrowed timer in timeout macros

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -38,10 +38,9 @@ macro_rules! block_timeout {
     ($timer:expr, $op:expr) => {
         {
             use $crate::hal::prelude::TimerExt;
-            let timer: &mut $crate::hal::Timer<_> = $timer;
 
             loop {
-                match timer.wait() {
+                match $timer.wait() {
                     Ok(()) =>
                         break Err($crate::util::TimeoutError::Timeout),
                     Err(nb::Error::WouldBlock) =>
@@ -78,10 +77,9 @@ macro_rules! repeat_timeout {
     ($timer:expr, $op:expr, $on_success:expr, $on_error:expr,) => {
         {
             use $crate::hal::prelude::TimerExt;
-            let timer: &mut $crate::hal::Timer<_> = $timer;
 
             loop {
-                match timer.wait() {
+                match $timer.wait() {
                     Ok(()) =>
                         break,
                     Err(nb::Error::WouldBlock) =>


### PR DESCRIPTION
If a user passes an argument of the wrong type, this change will make
the error message less explicit. However, this has the advantage of not
requiring exclusive access to said timer argument, which means the user
can use it in the operation it passes to the macro.