### PR TITLE
Remove dependency on nrf52832-hal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Hanno Braun <hanno@braun-robotics.com>"]
 edition = "2018"
 
 [dependencies]
+embedded-hal = "0.2.2"
 ieee802154   = "0.1.0"
 nb           = "0.1.1"
 serde        = { version = "1.0.79", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,3 @@ nb           = "0.1.1"
 serde        = { version = "1.0.79", default-features = false }
 serde_derive = "1.0.79"
 ssmarshal    = { version = "1.0", default-features = false }
-
-# Ideally we wouldn't need a dependency on nrf52-hal at all, and would depend on
-# embedded-hal instead. Unfortunately nrf52-hal doesn't implement the SPI traits
-# of embedded-hal yet, and we need nRF52 support because it's used on the
-# DWM1001 board.
-[dependencies.nrf52832-hal]
-git = "https://github.com/nrf-rs/nrf52-hal.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ ssmarshal    = { version = "1.0", default-features = false }
 # of embedded-hal yet, and we need nRF52 support because it's used on the
 # DWM1001 board.
 [dependencies.nrf52832-hal]
-version = "0.6.0"
+git = "https://github.com/nrf-rs/nrf52-hal.git"

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -43,13 +43,13 @@ impl<SPI> DW1000<SPI, Uninitialized>
     /// Requires the SPI peripheral and the chip select pin that are connected
     /// to the DW1000.
     pub fn new(
-        spim       : SPI,
+        spi        : SPI,
         chip_select: p0::P0_Pin<Output<PushPull>>
     )
         -> Self
     {
         DW1000 {
-            ll:     ll::DW1000::new(spim, chip_select),
+            ll:     ll::DW1000::new(spi, chip_select),
             seq:    Wrapping(0),
             _state: Uninitialized,
         }

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -13,8 +13,8 @@ use core::{
 
 use crate::hal::{
     gpio::{
-        p0,
         Output,
+        Pin,
         PushPull,
     },
 };
@@ -44,7 +44,7 @@ impl<SPI> DW1000<SPI, Uninitialized>
     /// to the DW1000.
     pub fn new(
         spi        : SPI,
-        chip_select: p0::P0_Pin<Output<PushPull>>
+        chip_select: Pin<Output<PushPull>>
     )
         -> Self
     {

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -402,7 +402,7 @@ impl<SPI, State> DW1000<SPI, State> where SPI: SpimExt {
 
 
 /// Represents a TX operation that might not have completed
-pub struct TxFuture<'r, SPI: 'r>(&'r mut DW1000<SPI, Ready>);
+pub struct TxFuture<'r, SPI>(&'r mut DW1000<SPI, Ready>);
 
 impl<'r, SPI> TxFuture<'r, SPI> where SPI: SpimExt {
     /// Wait for the data to be sent
@@ -472,7 +472,7 @@ impl<'r, SPI> TxFuture<'r, SPI> where SPI: SpimExt {
 
 
 /// Represents an RX operation that might not have finished
-pub struct RxFuture<'r, SPI: 'r>(&'r mut DW1000<SPI, Ready>);
+pub struct RxFuture<'r, SPI>(&'r mut DW1000<SPI, Ready>);
 
 impl<'r, SPI> RxFuture<'r, SPI> where SPI: SpimExt {
     /// Wait for data to be available

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,6 @@
 #![deny(missing_docs)]
 
 
-pub use nrf52832_hal as hal;
-
 pub mod ll;
 pub mod hl;
 pub mod ranging;

--- a/src/ll.rs
+++ b/src/ll.rs
@@ -101,10 +101,12 @@ impl<'s, R, SPI> RegAccessor<'s, R, SPI> where SPI: SpimExt {
 
         f(&mut r, &mut w);
 
-        let tx_buffer = <R as Writable>::buffer(&mut w);
-        init_header::<R>(true, tx_buffer);
+        let buffer = <R as Writable>::buffer(&mut w);
+        init_header::<R>(true, buffer);
 
-        self.0.spim.write(&mut self.0.chip_select, &tx_buffer)?;
+        self.0.chip_select.set_low();
+        <Spim<SPI> as spi::Write<u8>>::write(&mut self.0.spim, buffer)?;
+        self.0.chip_select.set_high();
 
         Ok(())
     }

--- a/src/ll.rs
+++ b/src/ll.rs
@@ -45,7 +45,7 @@ impl<SPI> DW1000<SPI> where SPI: SpimExt {
 /// Provides access to a register
 ///
 /// Please refer to [`DW1000`] for more information.
-pub struct RegAccessor<'s, R, SPI: 's>(&'s mut DW1000<SPI>, PhantomData<R>);
+pub struct RegAccessor<'s, R, SPI>(&'s mut DW1000<SPI>, PhantomData<R>);
 
 impl<'s, R, SPI> RegAccessor<'s, R, SPI> where SPI: SpimExt {
     /// Read from a register

--- a/src/ll.rs
+++ b/src/ll.rs
@@ -53,16 +53,14 @@ impl<'s, R, SPI> RegAccessor<'s, R, SPI> where SPI: SpimExt {
         where
             R: Register + Readable,
     {
-        let mut tx_buffer = [0; 3]; // 3 is the maximum header length
-        let header_len = init_header::<R>(false, &mut tx_buffer);
+        let mut r      = R::read();
+        let mut buffer = R::buffer(&mut r);
 
-        let mut r = R::read();
+        init_header::<R>(false, &mut buffer);
 
-        self.0.spim.read(
-            &mut self.0.chip_select,
-            &tx_buffer[0 .. header_len],
-            R::buffer(&mut r),
-        )?;
+        self.0.chip_select.set_low();
+        self.0.spim.transfer(buffer)?;
+        self.0.chip_select.set_high();
 
         Ok(r)
     }

--- a/src/ll.rs
+++ b/src/ll.rs
@@ -13,8 +13,8 @@ use embedded_hal::blocking::spi;
 use crate::hal::{
     prelude::*,
     gpio::{
-        p0,
         Output,
+        Pin,
         PushPull,
     },
 };
@@ -23,7 +23,7 @@ use crate::hal::{
 /// Entry point to the DW1000 driver API
 pub struct DW1000<SPI> {
     spi        : SPI,
-    chip_select: p0::P0_Pin<Output<PushPull>>,
+    chip_select: Pin<Output<PushPull>>,
 }
 
 impl<SPI> DW1000<SPI> {
@@ -33,7 +33,7 @@ impl<SPI> DW1000<SPI> {
     /// to the DW1000.
     pub fn new(
         spi        : SPI,
-        chip_select: p0::P0_Pin<Output<PushPull>>
+        chip_select: Pin<Output<PushPull>>
     )
         -> Self
     {

--- a/src/ll.rs
+++ b/src/ll.rs
@@ -22,7 +22,7 @@ use crate::hal::{
 
 /// Entry point to the DW1000 driver API
 pub struct DW1000<SPI> {
-    spim       : SPI,
+    spi        : SPI,
     chip_select: p0::P0_Pin<Output<PushPull>>,
 }
 
@@ -32,13 +32,13 @@ impl<SPI> DW1000<SPI> {
     /// Requires the SPI peripheral and the chip select pin that are connected
     /// to the DW1000.
     pub fn new(
-        spim       : SPI,
+        spi        : SPI,
         chip_select: p0::P0_Pin<Output<PushPull>>
     )
         -> Self
     {
         DW1000 {
-            spim,
+            spi,
             chip_select,
         }
     }
@@ -65,7 +65,7 @@ impl<'s, R, SPI> RegAccessor<'s, R, SPI>
         init_header::<R>(false, &mut buffer);
 
         self.0.chip_select.set_low();
-        self.0.spim.transfer(buffer)
+        self.0.spi.transfer(buffer)
             .map_err(|err| Error::Transfer(err))?;
         self.0.chip_select.set_high();
 
@@ -86,7 +86,7 @@ impl<'s, R, SPI> RegAccessor<'s, R, SPI>
         init_header::<R>(true, buffer);
 
         self.0.chip_select.set_low();
-        <SPI as spi::Write<u8>>::write(&mut self.0.spim, buffer)
+        <SPI as spi::Write<u8>>::write(&mut self.0.spi, buffer)
             .map_err(|err| Error::Write(err))?;
         self.0.chip_select.set_high();
 
@@ -113,7 +113,7 @@ impl<'s, R, SPI> RegAccessor<'s, R, SPI>
         init_header::<R>(true, buffer);
 
         self.0.chip_select.set_low();
-        <SPI as spi::Write<u8>>::write(&mut self.0.spim, buffer)
+        <SPI as spi::Write<u8>>::write(&mut self.0.spi, buffer)
             .map_err(|err| Error::Write(err))?;
         self.0.chip_select.set_high();
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -36,7 +36,11 @@ pub fn duration_between(earlier: Instant, later: Instant) -> Duration {
 macro_rules! block_timeout {
     ($timer:expr, $op:expr) => {
         {
-            use $crate::hal::prelude::TimerExt;
+            // Make sure the timer has the right type. If it isn't, the user
+            // should at least get a good error message.
+            fn check_type<T>(_: &mut T)
+                where T: embedded_hal::timer::CountDown {}
+            check_type($timer);
 
             loop {
                 match $timer.wait() {
@@ -75,7 +79,11 @@ macro_rules! block_timeout {
 macro_rules! repeat_timeout {
     ($timer:expr, $op:expr, $on_success:expr, $on_error:expr,) => {
         {
-            use $crate::hal::prelude::TimerExt;
+            // Make sure the timer has the right type. If it isn't, the user
+            // should at least get a good error message.
+            fn check_type<T>(_: &mut T)
+                where T: embedded_hal::timer::CountDown {}
+            check_type($timer);
 
             loop {
                 match $timer.wait() {


### PR DESCRIPTION
Theoretically this is good to go, but practically, this can't be merged without merging https://github.com/nrf-rs/nrf52-hal/pull/55 first. Otherwise dwm1001 can't be updated.

cc @jamesmunns :-)