### PR TITLE
Use serde derive feature instead of external crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,15 @@ travis-ci = { repository = "braun-robotics/rust-dw1000" }
 embedded-hal = "0.2.2"
 ieee802154   = "0.1.0"
 nb           = "0.1.1"
-serde        = { version = "1.0.79", default-features = false }
-serde_derive = "1.0.79"
-ssmarshal    = { version = "1.0", default-features = false }
+
+[dependencies.serde]
+version = "1.0.79"
+default-features = false
+features = ["derive"]
+
+[dependencies.ssmarshal]
+version = "1.0"
+default-features = false
 
 [dev-dependencies]
 # Required by the doc examples in the `macros` module.

--- a/src/ranging.rs
+++ b/src/ranging.rs
@@ -51,10 +51,6 @@ use serde::{
     Deserialize,
     Serialize,
 };
-use serde_derive::{
-    Deserialize,
-    Serialize,
-};
 use ssmarshal;
 
 use crate::{

--- a/src/time.rs
+++ b/src/time.rs
@@ -2,11 +2,7 @@
 
 
 use core::ops::Add;
-
-use serde_derive::{
-    Deserialize,
-    Serialize,
-};
+use serde::{Serialize, Deserialize};
 
 
 /// The maximum value of 40-bit system time stamps.


### PR DESCRIPTION
Unfortunately, serde with this feature and without this feature does not play well together.